### PR TITLE
checking if the element has any properties first

### DIFF
--- a/lib/epub-parser.js
+++ b/lib/epub-parser.js
@@ -384,7 +384,7 @@ EpubParser = (function() {
 					}
 
 					if(prop.match(/identifier$/i)) {
-						if(typeof metas[prop][0].$.id) {
+						if(metas[prop][0].$) {
 							if(metas[prop][0].$.id==uniqueIdentifier) {
 								if(typeof content == 'object') {
 									console.log('warning - content not fully parsed');


### PR DESCRIPTION
<dc:identifier> elements without any properties will crash on an `TypeError: Cannot read property 'id' of undefined`